### PR TITLE
Fixed multi tab refresh token issue

### DIFF
--- a/src/ASPNETCore2JwtAuthentication.AngularClient/src/app/app.component.ts
+++ b/src/ASPNETCore2JwtAuthentication.AngularClient/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component } from "@angular/core";
+import { Component, HostListener} from "@angular/core";
+import { RefreshTokenService } from "app/core";
 
 @Component({
   selector: "app-root",
@@ -6,5 +7,16 @@ import { Component } from "@angular/core";
   styleUrls: ["./app.component.css"]
 })
 export class AppComponent {
+  constructor(private refreshTokenService: RefreshTokenService) {}
 
+  @HostListener("window:unload", ["$event"])
+  unloadHandler() {
+    // Invalidate current tab as active RefreshToken timer
+    this.refreshTokenService.invalidateCurrentTabId();
+  }
+
+  @HostListener("window:beforeunload", ["$event"])
+  beforeUnloadHander() {
+    // ...
+  }
 }

--- a/src/ASPNETCore2JwtAuthentication.AngularClient/src/app/core/services/auth.service.ts
+++ b/src/ASPNETCore2JwtAuthentication.AngularClient/src/app/core/services/auth.service.ts
@@ -29,7 +29,7 @@ export class AuthService {
     private refreshTokenService: RefreshTokenService
   ) {
     this.updateStatusOnPageRefresh();
-    this.refreshTokenService.scheduleRefreshToken(this.isAuthUserLoggedIn());
+    this.refreshTokenService.scheduleRefreshToken(this.isAuthUserLoggedIn(), false);
   }
 
   login(credentials: Credentials): Observable<boolean> {
@@ -48,7 +48,7 @@ export class AuthService {
           }
           this.tokenStoreService.storeLoginSession(response);
           console.log("Logged-in user info", this.getAuthUser());
-          this.refreshTokenService.scheduleRefreshToken(true);
+          this.refreshTokenService.scheduleRefreshToken(true, true);
           this.authStatusSource.next(true);
           return true;
         }),


### PR DESCRIPTION
Hi,
This changes was fixed flowing issues:
- Invalid CurrentTabId When login information stored in LocalStorage (RememberMe is selected) and application restarted.
- Makes only one instance of application get RefreshToken from server, Specially when active timer tab was closed.
- Invalidate CurrentTabId of active timer tab when tab on closing tab.

Thanks.